### PR TITLE
Add flexible model path for Florence2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# StockPrep
+
+Este proyecto utiliza el modelo **Florence‑2** para generar descripciones de imágenes.
+
+## Configuración del modelo
+
+Ahora `Florence2Manager` acepta un parámetro opcional `model_id`. Si no se indica, se leerá la variable de entorno `FLORENCE2_MODEL_ID`. En caso de que ninguna esté definida se usará la ruta local predeterminada.
+
+```python
+from core.model_manager import Florence2Manager
+
+# Usar la variable de entorno
+manager = Florence2Manager()
+
+# O indicar la ruta o identificador manualmente
+manager = Florence2Manager(model_id="microsoft/Florence-2-large")
+```

--- a/src/core/model_manager.py
+++ b/src/core/model_manager.py
@@ -2,6 +2,7 @@
 Gestor del modelo Florence-2 - VERSIÓN CORREGIDA
 Este archivo incluye los parches necesarios para funcionar con timm 1.0.15
 """
+import os
 import torch
 from transformers import AutoModelForCausalLM, AutoProcessor
 from unittest.mock import patch
@@ -12,13 +13,22 @@ import warnings
 class Florence2Manager:
     """Clase que gestiona el modelo Florence-2"""
     
-    def __init__(self):
-        """Inicializa el gestor del modelo"""
+    def __init__(self, model_id: str | None = None):
+        """Inicializa el gestor del modelo
+
+        Parameters
+        ----------
+        model_id: str | None, optional
+            Ruta o identificador del modelo Florence-2. Si no se indica se
+            utilizará el valor de la variable de entorno ``FLORENCE2_MODEL_ID``
+            o la ruta local por defecto.
+        """
         self.model = None
         self.processor = None
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
-        # USAR MODELO LOCAL - Cambia esta ruta si es necesario
-        self.model_id = r"E:\Proyectos\Caption\models\Florence2-large"
+        # Ruta por defecto si no se especifica ninguna
+        env_model = os.getenv("FLORENCE2_MODEL_ID")
+        self.model_id = model_id or env_model or r"E:\Proyectos\Caption\models\Florence2-large"
         
     def fixed_get_imports(self, filename):
         """Arregla el problema de flash_attn en Windows"""

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -271,7 +271,8 @@ class StockPrepApp:
                 
                 # Importar y crear el gestor del modelo
                 from core.model_manager import Florence2Manager
-                self.model_manager = Florence2Manager()
+                ruta_modelo = os.environ.get("FLORENCE2_MODEL_ID")
+                self.model_manager = Florence2Manager(model_id=ruta_modelo)
                 
                 # Función callback para actualizar progreso
                 def actualizar_progreso(mensaje):

--- a/test-florence2-options.py
+++ b/test-florence2-options.py
@@ -75,9 +75,9 @@ print("   Pero puede necesitar los parches del model_manager.py")
 
 print("\n📝 Para usar en tu código:")
 print("\n# Para modelo Safetensors (recomendado):")
-print('manager = Florence2Manager(usar_local=False)')
+print('manager = Florence2Manager(model_id="microsoft/Florence-2-large")')
 print("\n# Para modelo local:")
-print('manager = Florence2Manager(usar_local=True)')
+print('manager = Florence2Manager(model_id=r"E:\\Proyectos\\Caption\\models\\Florence2-large")')
 
 # Prueba rápida opcional
 print("\n" + "-"*50)
@@ -92,11 +92,15 @@ if respuesta == 's':
     
     try:
         from core.model_manager import Florence2Manager
-        
-        usar_local = opcion == "1"
-        print(f"\nProbando {'modelo local' if usar_local else 'modelo Safetensors'}...")
-        
-        manager = Florence2Manager(usar_local=usar_local)
+
+        if opcion == "1":
+            modelo = r"E:\\Proyectos\\Caption\\models\\Florence2-large"
+        else:
+            modelo = "mrhendrey/Florence-2-large-ft-safetensors"
+
+        print(f"\nProbando {'modelo local' if opcion == '1' else 'modelo Safetensors'}...")
+
+        manager = Florence2Manager(model_id=modelo)
         exito = manager.cargar_modelo(callback=print)
         
         if exito:


### PR DESCRIPTION
## Summary
- allow passing a custom `model_id` to `Florence2Manager`
- read fallback model path from `FLORENCE2_MODEL_ID` env var
- propagate this new parameter in `main_window` and option tester script
- document usage in new README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685adef6604483259fce7fceedd733a6