### PR TITLE
Update path handling via config

### DIFF
--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -1,7 +1,7 @@
 # Configuración general del proyecto StockPrep
 
 # Carpeta de salida donde se copiarán imágenes renombradas y resultados
-ruta_salida: E:/Proyectos/StockPrep/salida
+ruta_salida: output/
 
 # Formato de exportación predeterminado
 # Opciones válidas: JSON, CSV, XML

--- a/src/core/model_manager.py
+++ b/src/core/model_manager.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 import gc
 import os
+import yaml
 
 import torch
 from transformers import AutoModelForCausalLM, AutoProcessor
@@ -20,13 +21,26 @@ torch.backends.cudnn.allow_tf32 = True
 class Florence2Manager:
     """Carga y gestiona un checkpoint local de Florence‑2."""
 
-    def __init__(self):
+    def __init__(self, model_path: str | None = None):
         self.model = None
         self.processor = None
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
-        self.model_id = str(
-            Path("E:/Proyectos/Caption/models/Florence-2-large-ft-safetensors").resolve()
-        )
+        if model_path is not None:
+            self.model_id = str(Path(model_path).resolve())
+        else:
+            self.model_id = self._leer_model_path()
+
+    def _leer_model_path(self) -> str:
+        """Obtiene la ruta del modelo desde el archivo de configuración."""
+        try:
+            with open("config/settings.yaml", "r", encoding="utf-8") as f:
+                config = yaml.safe_load(f)
+            ruta = config.get("modelo", {}).get(
+                "ruta_local", "modelos/Florence-2-large.safetensors"
+            )
+            return str(Path(ruta).resolve())
+        except Exception:
+            return str(Path("modelos/Florence-2-large.safetensors").resolve())
 
     # ---------------------------------------------------------------------
     #  Utilidad para evitar que Flash‑Attn se cargue si no está disponible

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -10,6 +10,7 @@ import threading
 import queue
 from pathlib import Path
 import os
+import yaml
 
 class StockPrepApp(Window):
     """Aplicación principal con interfaz gráfica"""
@@ -34,7 +35,7 @@ class StockPrepApp(Window):
 
         # Variables de control
         self.carpeta_entrada = tk.StringVar()
-        self.carpeta_salida = tk.StringVar(value=str(Path.cwd() / "output"))
+        self.carpeta_salida = tk.StringVar(value=self._leer_config_salida())
         self.modelo_cargado = False
         self.procesando = False
         
@@ -50,6 +51,15 @@ class StockPrepApp(Window):
         
         # Iniciar verificación de mensajes
         self.verificar_mensajes()
+
+    def _leer_config_salida(self):
+        """Lee la ruta de salida predeterminada desde settings.yaml."""
+        try:
+            with open("config/settings.yaml", "r", encoding="utf-8") as f:
+                config = yaml.safe_load(f)
+            return str(Path(config.get("ruta_salida", "output")).resolve())
+        except Exception:
+            return str(Path.cwd() / "output")
 
     def crear_interfaz(self):
         """Crea todos los elementos de la interfaz"""


### PR DESCRIPTION
## Summary
- read model path from config in `Florence2Manager`
- read default output directory from config for the GUI
- set `ruta_salida` in `settings.yaml` to a relative path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c91039f1883258e1c50bbd1dbc282