### PR TITLE
Fix GPU check in scrip_prueba

### DIFF
--- a/scrip_prueba.py
+++ b/scrip_prueba.py
@@ -4,7 +4,10 @@ from transformers import AutoProcessor, AutoModelForCausalLM
 # Verificar GPU
 print("CUDA disponible:", torch.cuda.is_available())
 print("Versión PyTorch:", torch.__version__)
-print("GPU:", torch.cuda.get_device_name(0))
+if torch.cuda.is_available():
+    print("GPU:", torch.cuda.get_device_name(0))
+else:
+    print("No GPU found")
 
 # Cargar modelo Florence-2
 try:


### PR DESCRIPTION
## Summary
- avoid calling `torch.cuda.get_device_name(0)` when CUDA is unavailable

## Testing
- `python scrip_prueba.py` *(fails: ModuleNotFoundError: No module named 'torch')*
- `python verificar_instalacion.py`

------
https://chatgpt.com/codex/tasks/task_e_685d560481c88325a0558256b1a1ba7f