### PR TITLE
Adjust output path handling

### DIFF
--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -1,7 +1,7 @@
 # Configuración general del proyecto StockPrep
 
 # Carpeta de salida donde se copiarán imágenes renombradas y resultados
-ruta_salida: E:/Proyectos/StockPrep/salida
+ruta_salida: output/
 
 # Formato de exportación predeterminado
 # Opciones válidas: JSON, CSV, XML

--- a/src/io/output_handler.py
+++ b/src/io/output_handler.py
@@ -18,11 +18,20 @@ class BatchEngine:
 
     def _leer_config_salida(self):
         try:
-            with open("config/settings.yaml", "r", encoding="utf-8") as f:
+            repo_root = Path(__file__).resolve().parents[2]
+            config_path = repo_root / "config" / "settings.yaml"
+            with open(config_path, "r", encoding="utf-8") as f:
                 config = yaml.safe_load(f)
-            return config.get("ruta_salida", "salida")
-        except Exception:
-            return "salida"
+
+            ruta = config.get("ruta_salida", "output")
+            ruta_path = Path(ruta)
+            if not ruta_path.is_absolute():
+                ruta_path = repo_root / ruta
+
+            return str(ruta_path)
+        except Exception as e:
+            self._log(f"⚠️ No se pudo leer la ruta de salida: {e}")
+            return str(Path.cwd() / "output")
 
     def _log(self, message):
         if self.status_callback:


### PR DESCRIPTION
## Summary
- make default output folder relative (`config/settings.yaml`)
- ensure `BatchEngine` resolves that folder from repository root and log errors

## Testing
- `python verificar_instalacion.py` *(fails: NameError: name 'torch' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_685d5669daf0832599aa66cd6a8d9130