### PR TITLE
Fix local model path and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,15 @@
 └── verificar_instalacion.py
 ```
 
+## Configuración del modelo
+
+El archivo [`config/settings.yaml`](config/settings.yaml) incluye la ruta
+`ruta_local` para cargar Florence‑2 desde una carpeta local. Asegúrate de que
+esa ruta apunte al **directorio** que contiene todos los pesos y archivos de
+configuración (por ejemplo `models/Florence-2-large-ft-safetensors`). Si prefieres,
+puedes definir la variable de entorno `FLORENCE2_MODEL_PATH` con esa misma ruta.
+
+
 ## License
 
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -14,7 +14,8 @@ exportar_txt: true
 modelo:
   nombre: Florence-2-large
   tipo: safetensors
-  ruta_local: models/Florence-2-large.safetensors
+  # Ruta a la carpeta que contiene los pesos y configuraciones de Florence‑2
+  ruta_local: models/Florence-2-large-ft-safetensors
   dtype: float32
   # ⚠️ NO TOCAR: esta opción evita fallos críticos al cargar Florence‑2 en Windows. Solo se usa flash_attn en Linux.
   flash_attn_enabled: false  # Florence2 requiere flash_attn solo en Linux. Desactivado explícitamente en model_manager.py


### PR DESCRIPTION
## Summary
- point settings.yaml to Florence-2 folder instead of single safetensors file
- document how to configure the local model directory in README

## Testing
- `python verificar_instalacion.py` *(fails: torch not installed)*
- `python main.py` *(fails: no $DISPLAY)*


------
https://chatgpt.com/codex/tasks/task_e_685d69f3e0ac83259594cebc10509b1a